### PR TITLE
Make options.args parameter optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = function(opts) {
   var from = opts.from;
   var to   = opts.to;
   var ext  = opts.ext;
-  var args = opts.args;
+  var args = opts.args || [];
 
   if (!from) { throw new PluginError(PluginName, '"from" is not defined'); }
   if (!to) { throw new PluginError(PluginName, '"to" is not defined'); }


### PR DESCRIPTION
The documentation does not specify that `options.args` is required, but its absence causes an error.

    pandoc: [object Object]: openFile: does not exist (No such file or directory)

I presume this is caused by passing a `undefined` into `pdc`. This patch resolves the issue by using an empty array where `opts.args` is `undefined`.